### PR TITLE
bug fixes for duplicate detection, and detection of cards lower than 6 for short-deck

### DIFF
--- a/src/OddsCalculator.ts
+++ b/src/OddsCalculator.ts
@@ -3,7 +3,7 @@
  *
  */
 import * as _ from 'lodash';
-import { Card, Rank, Suit } from './Card';
+import { Card, Suit } from './Card';
 import { CardGroup } from './CardGroup';
 import { FullDeckGame, IGame, ShortDeckGame } from './Game';
 import { HandRank } from './HandRank';
@@ -71,39 +71,27 @@ export class OddsCalculator {
       throw new Error('The board must contain 0, 3, 4 or 5 cards');
     }
 
+    const allGroups: CardGroup[] = board ? cardgroups.concat(board) : cardgroups;
+    let allCards: Card[] = [];
+    allGroups.forEach((group: CardGroup) => {
+      allCards = allCards.concat(group);
+    });
     // Invalid card values
     if (gameVariant === 'short') {
-      const allGroups: CardGroup[] = board ? cardgroups.concat(board) : cardgroups;
-      allGroups.forEach((cardgroup: CardGroup[]) => {
-        for (let i: number = 0; i < cardgroup.length; i += 1) {
-          for (const card of cardgroups[i]) {
-            if (card.getRank() < 6) {
-              throw new Error('Only cards rank 6 through A are valid.');
-            }
-          }
+      allCards.forEach((card: Card) => {
+        if (card.getRank() < 6) {
+          throw new Error('Only cards rank 6 through A are valid.');
         }
       });
     }
+    const uniqCards: Card[] = _.uniqBy(allCards, (card: Card) => {
+      return card.getRank() + '-' + card.getSuit();
+    });
 
-    // Detect duplicate cards
-    for (let i: number = 0; i < cardgroups.length; i += 1) {
-      for (let j: number = i + 1; j < cardgroups.length; j += 1) {
-        for (const card of cardgroups[j]) {
-          if (cardgroups[i].contains(card)) {
-            throw new Error('Detected duplicate cards');
-          }
-        }
-      }
+    if (uniqCards.length !== allCards.length) {
+      throw new Error('Detected duplicate cards');
     }
-    if (board && board.length) {
-      for (let i: number = 0; i < cardgroups.length; i += 1) {
-        for (const card of cardgroups[i]) {
-          if (board.contains(card)) {
-            throw new Error('Detected duplicate cards');
-          }
-        }
-      }
-    }
+
     iterations = iterations || 0;
 
     let game: IGame;

--- a/test/02-cardgroup.ts
+++ b/test/02-cardgroup.ts
@@ -2,7 +2,7 @@
  * Tests for CardGroup class
  */
 import { expect } from 'chai';
-import { CardGroup, Rank, Suit } from '../src/index';
+import { Card, CardGroup, Rank, Suit } from '../src/index';
 
 describe('CardGroup', () => {
   describe('fromString()', () => {
@@ -72,5 +72,21 @@ describe('CardGroup', () => {
       expect(cardgroup[3].getRank()).to.equal(Rank.THREE);
       expect(cardgroup[3].getSuit()).to.equal(Suit.DIAMOND);
     });
+  });
+
+  it('CardGroup contains', () => {
+    const cardgroup: CardGroup = CardGroup.fromString('Ac 3d 5s 5h');
+    let card: Card = Card.fromString('Ac');
+    expect(cardgroup.contains(card)).to.be.true;
+    card = Card.fromString('3d');
+    expect(cardgroup.contains(card)).to.be.true;
+    card = Card.fromString('5s');
+    expect(cardgroup.contains(card)).to.be.true;
+    card = Card.fromString('5h');
+    expect(cardgroup.contains(card)).to.be.true;
+    card = Card.fromString('Kc');
+    expect(cardgroup.contains(card)).to.be.false;
+    card = Card.fromString('Jc');
+    expect(cardgroup.contains(card)).to.be.false;
   });
 });

--- a/test/04-odds-calculator.ts
+++ b/test/04-odds-calculator.ts
@@ -34,6 +34,27 @@ describe('OddsCalculator', () => {
 
     expect(OddsCalculator.calculate.bind(null, [player1Cards, player2Cards], board))
       .to.throw(Error, 'Detected duplicate cards');
+
+    player1Cards = CardGroup.fromString('AhAh');
+    player2Cards = CardGroup.fromString('AcAd');
+    board = CardGroup.fromString('2d,Kd,4s');
+
+    expect(OddsCalculator.calculate.bind(null, [player1Cards, player2Cards], board))
+      .to.throw(Error, 'Detected duplicate cards');
+
+    player1Cards = CardGroup.fromString('3d,4d');
+    player2Cards = CardGroup.fromString('JcJc');
+    board = CardGroup.fromString('2d,Kd,Ac');
+
+    expect(OddsCalculator.calculate.bind(null, [player1Cards, player2Cards], board))
+      .to.throw(Error, 'Detected duplicate cards');
+
+    player1Cards = CardGroup.fromString('AdAh');
+    player2Cards = CardGroup.fromString('3d,4d');
+    board = CardGroup.fromString('2d,Ac,Ac');
+
+    expect(OddsCalculator.calculate.bind(null, [player1Cards, player2Cards], board))
+      .to.throw(Error, 'Detected duplicate cards');
   });
 
   it('full board', () => {
@@ -44,6 +65,24 @@ describe('OddsCalculator', () => {
 
     expect(result.equities[0].getEquity()).to.equal(100);
     expect(result.equities[1].getEquity()).to.equal(0);
+  });
+
+  it('flop only board', () => {
+    let player1Cards: CardGroup = CardGroup.fromString('5d6d');
+    let player2Cards: CardGroup = CardGroup.fromString('4h4c');
+    let board: CardGroup = CardGroup.fromString('3d,4d,7d');
+    let result: OddsCalculator = OddsCalculator.calculate([player1Cards, player2Cards], board);
+
+    expect(result.equities[0].getEquity()).to.equal(100);
+    expect(result.equities[1].getEquity()).to.equal(0);
+
+    player1Cards = CardGroup.fromString('5d6d');
+    player2Cards = CardGroup.fromString('4h4c');
+    board = CardGroup.fromString('3d,4d,9d');
+    result = OddsCalculator.calculate([player1Cards, player2Cards], board);
+
+    expect(result.equities[0].getEquity()).to.be.within(67, 69);
+    expect(result.equities[1].getEquity()).to.be.within(31, 33);
   });
 
   it('one card left', () => {

--- a/test/04-odds-calculator.ts
+++ b/test/04-odds-calculator.ts
@@ -140,7 +140,7 @@ describe('OddsCalculator', () => {
   it('no board', () => {
     const player1Cards: CardGroup = CardGroup.fromString('AcAh');
     const player2Cards: CardGroup = CardGroup.fromString('7c7h');
-    const result: OddsCalculator = OddsCalculator.calculate([player1Cards, player2Cards], null, null, 10000);
+    const result: OddsCalculator = OddsCalculator.calculate([player1Cards, player2Cards], undefined, undefined, 10000);
 
     const oddsPlayer1: number = result.equities[0].getEquity();
     const oddsPlayer2: number = result.equities[1].getEquity();
@@ -156,7 +156,7 @@ describe('OddsCalculator', () => {
   it('public methods', () => {
     const player1Cards: CardGroup = CardGroup.fromString('AcAh');
     const player2Cards: CardGroup = CardGroup.fromString('7c7h');
-    let result: OddsCalculator = OddsCalculator.calculate([player1Cards, player2Cards], null, null, 10);
+    let result: OddsCalculator = OddsCalculator.calculate([player1Cards, player2Cards], undefined, undefined, 10);
 
     expect(result.getHandRank(1)).to.be.an.instanceof(HandRank);
     expect(result.getHandRank(0)).to.be.an.instanceof(HandRank);

--- a/test/05-odds-calculator-ties.ts
+++ b/test/05-odds-calculator-ties.ts
@@ -9,7 +9,7 @@ describe('OddsCalculator (ties)', () => {
   it('no board', () => {
     const player1Cards: CardGroup = CardGroup.fromString('AsAc');
     const player2Cards: CardGroup = CardGroup.fromString('AhAd');
-    const result: OddsCalculator = OddsCalculator.calculate([player1Cards, player2Cards], null, null, 10000);
+    const result: OddsCalculator = OddsCalculator.calculate([player1Cards, player2Cards], undefined, undefined, 10000);
 
     const oddsPlayer1: number = result.equities[0].getEquity();
     const oddsPlayer2: number = result.equities[1].getEquity();
@@ -36,7 +36,7 @@ describe('OddsCalculator (ties)', () => {
     const player1Cards: CardGroup = CardGroup.fromString('AsAc');
     const player2Cards: CardGroup = CardGroup.fromString('AhAd');
     const player3Cards: CardGroup = CardGroup.fromString('KsKc');
-    const result: OddsCalculator = OddsCalculator.calculate([player1Cards, player2Cards, player3Cards], null, null, 10000);
+    const result: OddsCalculator = OddsCalculator.calculate([player1Cards, player2Cards, player3Cards], undefined, undefined, 10000);
 
     const oddsPlayer1: number = result.equities[0].getEquity();
     const oddsPlayer2: number = result.equities[1].getEquity();

--- a/test/06-short-deck-variant.ts
+++ b/test/06-short-deck-variant.ts
@@ -10,7 +10,7 @@ describe('OddsCalculator: short-deck', () => {
   it('no board', () => {
     const player1Cards: CardGroup = CardGroup.fromString('AcAh');
     const player2Cards: CardGroup = CardGroup.fromString('JdTd');
-    const result: OddsCalculator = OddsCalculator.calculate([player1Cards, player2Cards], null, 'short', 10000);
+    const result: OddsCalculator = OddsCalculator.calculate([player1Cards, player2Cards], undefined, 'short', 10000);
 
     const oddsPlayer1: number = result.equities[0].getEquity();
     const oddsPlayer2: number = result.equities[1].getEquity();

--- a/test/06-short-deck-variant.ts
+++ b/test/06-short-deck-variant.ts
@@ -95,10 +95,17 @@ describe('OddsCalculator: short-deck', () => {
   });
 
   it('throws error when card lower than 6 given', () => {
-    const player1Cards: CardGroup = CardGroup.fromString('AcAh');
-    const player2Cards: CardGroup = CardGroup.fromString('Jd5d');
+    let player1Cards: CardGroup = CardGroup.fromString('AcAh');
+    let player2Cards: CardGroup = CardGroup.fromString('Jd5d');
 
     expect(OddsCalculator.calculate.bind(null, [player1Cards, player2Cards], null, 'short'))
+      .to.throw(Error, 'Only cards rank 6 through A are valid');
+
+    player1Cards = CardGroup.fromString('KsQs');
+    player2Cards = CardGroup.fromString('AdTd');
+    const board: CardGroup = CardGroup.fromString('JsTs5c');
+
+    expect(OddsCalculator.calculate.bind(null, [player1Cards, player2Cards], board, 'short'))
       .to.throw(Error, 'Only cards rank 6 through A are valid');
   });
 


### PR DESCRIPTION
Couple bug fixes around input validation

1) If the board contains a card that is in the player's hand, an error should be thrown.
2) If the player's hand consists of two of the same card, i.e. JcJc, an error should be thrown
3) (short-deck specific): If the board contains a card lower than a 6, an error should be thrown.

items 1 & 2 are solved in the same fix by refactoring how duplicates are detected. Rather than iterating the players hands and boards, and comparing the individual cards, I am instead creating a list of the all input cards, and a list of all unique cards, then comparing the list lengths. Any differences indicates a duplicate.

item 3 is a bug in how I had implement the forEach loop here:

```
const allGroups: CardGroup[] = board ? cardgroups.concat(board) : cardgroups;
      allGroups.forEach((cardgroup: CardGroup[]) => {
```
Where the elements being iterated are CardGroup not CardGroup. I was surprised the linter did not catch this tbh.

In addition to this, tests were written for all three of the scenarios found to be failing, as well as the CardGroup.contains() method, as it had lost coverage by not being implicitly called by OddsCalculator.calculate anymore.